### PR TITLE
Fix query result typing in Header

### DIFF
--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -21,7 +21,7 @@ export function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   // Fetch unread messages count
-  const { data: conversations } = useQuery({
+  const { data: conversations } = useQuery<any[]>({
     queryKey: ["/api/messages"],
     enabled: !!user,
   });


### PR DESCRIPTION
## Summary
- specify return type for useQuery in the header component

## Testing
- `npm run check` *(fails: TypeScript errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_683f3ae9e14883309064078b0f7f0d79